### PR TITLE
消除編譯錯誤

### DIFF
--- a/src/register.c
+++ b/src/register.c
@@ -261,7 +261,7 @@ void ccmmc_register_extend_name(CcmmcTmp *tmp, char *extend_name)
 
 void ccmmc_register_caller_save(CcmmcRegPool *pool)
 {
-    char buf[25];
+    char buf[30];
     int bound = pool->num;
     if (pool->top < bound)
         bound = pool->top;

--- a/src/semantic-analysis.c
+++ b/src/semantic-analysis.c
@@ -665,7 +665,7 @@ static bool decl_variable(
     // Other children are newly declared variables
     for (CcmmcAst *init_id = var_decl->child->right_sibling; init_id != NULL;
          init_id = init_id->right_sibling) {
-        assert(init_id->type_node = CCMMC_AST_NODE_ID);
+        assert(init_id->type_node == CCMMC_AST_NODE_ID);
         const char *var_str = init_id->value_id.name;
         if (ccmmc_symbol_scope_exist(table->current, var_str)) {
             any_error = true;


### PR DESCRIPTION
sprintf 那行，編譯器會計算格式化字串最長可能有多長，然後發現 buf 只有 25 可能裝不下導致 buffer overflow

assert 那行，應該是誤把 == 寫成 = 了